### PR TITLE
feat: fix profile pictures and space icons not loading

### DIFF
--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -47,6 +47,7 @@ export function ChatHeader({ name, topic, isDm, roomId }: ChatHeaderProps) {
       userId: other.userId,
       displayName: other.name || other.userId,
       avatarUrl: mxcToHttp(other.getMxcAvatarUrl(), client.getHomeserverUrl()),
+      mxcAvatarUrl: other.getMxcAvatarUrl() ?? null,
     };
   }, [isDm, roomId, myUserId]);
 
@@ -76,6 +77,7 @@ export function ChatHeader({ name, topic, isDm, roomId }: ChatHeaderProps) {
           <Avatar
             name={otherUser.displayName}
             url={otherUser.avatarUrl}
+            mxcUrl={otherUser.mxcAvatarUrl}
             size={24}
             presence={otherPresence}
           />

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -343,6 +343,7 @@ export const MessageItem = memo(function MessageItem({ message, showHeader }: Me
             userId={message.senderId}
             displayName={message.senderName}
             avatarUrl={message.senderAvatar}
+            mxcAvatarUrl={message.senderMxcAvatar}
             anchorEl={popoverAnchor}
             onClose={() => setPopoverAnchor(null)}
           />
@@ -364,6 +365,7 @@ export const MessageItem = memo(function MessageItem({ message, showHeader }: Me
           <Avatar
             name={message.senderName}
             url={message.senderAvatar}
+            mxcUrl={message.senderMxcAvatar}
             size={40}
           />
         </button>
@@ -389,6 +391,7 @@ export const MessageItem = memo(function MessageItem({ message, showHeader }: Me
             userId={message.senderId}
             displayName={message.senderName}
             avatarUrl={message.senderAvatar}
+            mxcAvatarUrl={message.senderMxcAvatar}
             anchorEl={popoverAnchor}
             onClose={() => setPopoverAnchor(null)}
           />

--- a/src/components/chat/PinnedMessages.tsx
+++ b/src/components/chat/PinnedMessages.tsx
@@ -8,6 +8,7 @@ interface PinnedMessage {
   senderId: string;
   senderName: string;
   senderAvatar: string | null;
+  senderMxcAvatar: string | null;
   body: string;
   timestamp: number;
 }
@@ -48,6 +49,7 @@ export function PinnedMessages({ roomId, onClose }: PinnedMessagesProps) {
           senderId: event.getSender() ?? "",
           senderName: sender?.name ?? event.getSender() ?? "Unknown",
           senderAvatar: sender ? mxcToHttp(sender.getMxcAvatarUrl(), hsUrl) : null,
+          senderMxcAvatar: sender?.getMxcAvatarUrl() ?? null,
           body: event.getContent()?.body ?? "(no text)",
           timestamp: event.getTs(),
         });
@@ -80,7 +82,7 @@ export function PinnedMessages({ roomId, onClose }: PinnedMessagesProps) {
         {pinned.map((msg) => (
           <div key={msg.eventId} className="rounded-sm p-3 hover:bg-bg-hover">
             <div className="mb-1 flex items-center gap-2">
-              <Avatar name={msg.senderName} url={msg.senderAvatar} size={20} />
+              <Avatar name={msg.senderName} url={msg.senderAvatar} mxcUrl={msg.senderMxcAvatar} size={20} />
               <span className="text-xs font-medium text-text-primary">{msg.senderName}</span>
               <span className="text-[10px] text-text-muted">
                 {new Date(msg.timestamp).toLocaleDateString()}

--- a/src/components/chat/SearchPanel.tsx
+++ b/src/components/chat/SearchPanel.tsx
@@ -8,6 +8,7 @@ interface SearchResult {
   senderId: string;
   senderName: string;
   senderAvatar: string | null;
+  senderMxcAvatar: string | null;
   body: string;
   timestamp: number;
 }
@@ -56,6 +57,7 @@ export function SearchPanel({ roomId, onClose }: SearchPanelProps) {
           senderId: event?.sender ?? "",
           senderName: sender?.displayName ?? event?.sender ?? "Unknown",
           senderAvatar: sender ? mxcToHttp(sender.avatarUrl, hsUrl) : null,
+          senderMxcAvatar: sender?.avatarUrl ?? null,
           body: event?.content?.body ?? "",
           timestamp: event?.origin_server_ts ?? 0,
         };
@@ -110,7 +112,7 @@ export function SearchPanel({ roomId, onClose }: SearchPanelProps) {
         {results.map((msg) => (
           <div key={msg.eventId} className="rounded-sm p-3 hover:bg-bg-hover">
             <div className="mb-1 flex items-center gap-2">
-              <Avatar name={msg.senderName} url={msg.senderAvatar} size={20} />
+              <Avatar name={msg.senderName} url={msg.senderAvatar} mxcUrl={msg.senderMxcAvatar} size={20} />
               <span className="text-xs font-medium text-text-primary">{msg.senderName}</span>
               <span className="text-[10px] text-text-muted">
                 {new Date(msg.timestamp).toLocaleDateString(undefined, {

--- a/src/components/chat/ThreadPanel.tsx
+++ b/src/components/chat/ThreadPanel.tsx
@@ -128,7 +128,7 @@ export function ThreadPanel() {
                 {isRoot && (
                   <div className="mb-3 rounded-lg bg-bg-secondary p-3">
                     <div className="mb-1 flex items-center gap-2">
-                      <Avatar name={msg.senderName} url={msg.senderAvatar} size={24} />
+                      <Avatar name={msg.senderName} url={msg.senderAvatar} mxcUrl={msg.senderMxcAvatar} size={24} />
                       <span className="text-sm font-medium text-text-primary">
                         {msg.senderName}
                       </span>
@@ -157,7 +157,7 @@ export function ThreadPanel() {
 
                 {!isRoot && showHeader && (
                   <div className="mt-3 flex gap-2 py-0.5">
-                    <Avatar name={msg.senderName} url={msg.senderAvatar} size={32} />
+                    <Avatar name={msg.senderName} url={msg.senderAvatar} mxcUrl={msg.senderMxcAvatar} size={32} />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-baseline gap-2">
                         <span className="text-sm font-medium text-text-primary">

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { PresenceStatus } from "@/stores/presenceStore";
+import { useMatrixImage } from "@/utils/useMatrixImage";
 
 interface AvatarProps {
   name: string;
-  url: string | null;
+  url?: string | null;
+  mxcUrl?: string | null;
   size?: number;
   presence?: PresenceStatus | null;
 }
@@ -50,23 +52,30 @@ function Initials({ name, size }: { name: string; size: number }) {
   );
 }
 
-export function Avatar({ name, url, size = 40, presence }: AvatarProps) {
+export function Avatar({ name, url, mxcUrl, size = 40, presence }: AvatarProps) {
   const [imgError, setImgError] = useState(false);
+  const { src: blobSrc, loading } = useMatrixImage(mxcUrl, size, size);
 
-  // Reset error state when URL changes (e.g., re-login, profile update)
+  const effectiveUrl = blobSrc ?? url ?? null;
+
   useEffect(() => {
     setImgError(false);
-  }, [url]);
+  }, [effectiveUrl]);
 
   const dotSize = Math.max(10, size * 0.3);
 
-  const avatar = url && !imgError ? (
+  const avatar = effectiveUrl && !imgError ? (
     <img
-      src={url}
+      src={effectiveUrl}
       alt={name}
       className="flex-shrink-0 rounded-full object-cover"
       style={{ width: size, height: size }}
       onError={() => setImgError(true)}
+    />
+  ) : loading ? (
+    <div
+      className="flex-shrink-0 animate-pulse rounded-full bg-bg-secondary"
+      style={{ width: size, height: size }}
     />
   ) : (
     <Initials name={name} size={size} />

--- a/src/components/common/QuickSwitcher.tsx
+++ b/src/components/common/QuickSwitcher.tsx
@@ -119,7 +119,7 @@ export function QuickSwitcher({ onClose }: QuickSwitcherProps) {
                 i === selectedIndex ? "bg-accent/20 text-text-primary" : "text-text-secondary hover:bg-bg-hover"
               }`}
             >
-              <Avatar name={room.name} url={room.avatarUrl} size={28} />
+              <Avatar name={room.name} url={room.avatarUrl} mxcUrl={room.mxcAvatarUrl} size={28} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-text-muted">

--- a/src/components/common/UserPopover.tsx
+++ b/src/components/common/UserPopover.tsx
@@ -10,11 +10,12 @@ interface UserPopoverProps {
   userId: string;
   displayName: string;
   avatarUrl: string | null;
+  mxcAvatarUrl?: string | null;
   anchorEl: HTMLElement;
   onClose: () => void;
 }
 
-export function UserPopover({ userId, displayName, avatarUrl, anchorEl, onClose }: UserPopoverProps) {
+export function UserPopover({ userId, displayName, avatarUrl, mxcAvatarUrl, anchorEl, onClose }: UserPopoverProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState({ top: 0, left: 0 });
   const [starting, setStarting] = useState(false);
@@ -26,6 +27,7 @@ export function UserPopover({ userId, displayName, avatarUrl, anchorEl, onClose 
   const hsUrl = client?.getHomeserverUrl() ?? "";
   const user = client?.getUser(userId);
   const liveAvatarUrl = mxcToHttp(user?.avatarUrl, hsUrl);
+  const liveMxcAvatarUrl = user?.avatarUrl ?? mxcAvatarUrl ?? null;
   const liveName = user?.displayName ?? displayName;
 
   useEffect(() => {
@@ -123,6 +125,7 @@ export function UserPopover({ userId, displayName, avatarUrl, anchorEl, onClose 
           <Avatar
             name={liveName}
             url={liveAvatarUrl ?? avatarUrl}
+            mxcUrl={liveMxcAvatarUrl}
             size={64}
             presence={presence?.presence ?? null}
           />

--- a/src/components/members/MemberItem.tsx
+++ b/src/components/members/MemberItem.tsx
@@ -19,6 +19,7 @@ export function MemberItem({ member }: MemberItemProps) {
       <Avatar
         name={member.displayName}
         url={member.avatarUrl}
+        mxcUrl={member.mxcAvatarUrl}
         size={32}
         presence={presence}
       />

--- a/src/components/modals/CreateDmModal.tsx
+++ b/src/components/modals/CreateDmModal.tsx
@@ -11,6 +11,7 @@ interface SearchResult {
   userId: string;
   displayName: string | null;
   avatarUrl: string | null;
+  mxcAvatarUrl: string | null;
 }
 
 export function CreateDmModal() {
@@ -43,6 +44,7 @@ export function CreateDmModal() {
           userId: u.user_id,
           displayName: u.display_name ?? null,
           avatarUrl: mxcToHttp(u.avatar_url, hsUrl),
+          mxcAvatarUrl: u.avatar_url ?? null,
         }))
       );
     } catch (err) {
@@ -169,6 +171,7 @@ export function CreateDmModal() {
               <Avatar
                 name={user.displayName ?? user.userId}
                 url={user.avatarUrl}
+                mxcUrl={user.mxcAvatarUrl}
                 size={36}
               />
               <div className="min-w-0 flex-1">

--- a/src/components/modals/RoomSettingsModal.tsx
+++ b/src/components/modals/RoomSettingsModal.tsx
@@ -218,7 +218,7 @@ function OverviewTab({
       {/* Room avatar */}
       <div className="flex items-center gap-4">
         <div className="relative">
-          <Avatar name={room.name} url={displayAvatarUrl} size={64} />
+          <Avatar name={room.name} url={displayAvatarUrl} mxcUrl={roomAvatarMxc ?? room.mxcAvatarUrl} size={64} />
           {uploadingAvatar && (
             <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
@@ -490,6 +490,7 @@ function MembersTab({ roomId, userId }: { roomId: string; userId: string | null 
               <Avatar
                 name={member.displayName}
                 url={member.avatarUrl}
+                mxcUrl={member.mxcAvatarUrl}
                 size={36}
               />
               <div className="min-w-0 flex-1">

--- a/src/components/modals/SpaceSettingsModal.tsx
+++ b/src/components/modals/SpaceSettingsModal.tsx
@@ -212,7 +212,7 @@ function OverviewTab({
       }
       if (avatarMxc) {
         await client.sendStateEvent(spaceId, "m.room.avatar" as any, { url: avatarMxc }, "");
-        updateRoom(spaceId, { avatarUrl: mxcToHttp(avatarMxc, homeserverUrl) });
+        updateRoom(spaceId, { avatarUrl: mxcToHttp(avatarMxc, homeserverUrl), mxcAvatarUrl: avatarMxc });
       }
       setSuccessMsg("Settings saved!");
       setTimeout(() => closeModal(), 600);
@@ -252,7 +252,7 @@ function OverviewTab({
       {/* Space avatar */}
       <div className="flex items-center gap-4">
         <div className="relative">
-          <Avatar name={space.name} url={displayAvatarUrl} size={64} />
+          <Avatar name={space.name} url={displayAvatarUrl} mxcUrl={avatarMxc ?? space.mxcAvatarUrl} size={64} />
           {uploadingAvatar && (
             <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
@@ -518,6 +518,7 @@ function MembersTab({ spaceId, userId }: { spaceId: string; userId: string | nul
               <Avatar
                 name={member.displayName}
                 url={member.avatarUrl}
+                mxcUrl={member.mxcAvatarUrl}
                 size={36}
               />
               <div className="min-w-0 flex-1">

--- a/src/components/modals/UserSettingsModal.tsx
+++ b/src/components/modals/UserSettingsModal.tsx
@@ -92,7 +92,7 @@ export function UserSettingsModal() {
         {/* Avatar section */}
         <div className="flex items-center gap-4">
           <div className="relative">
-            <Avatar name={displayName || "?"} url={avatarHttpUrl} size={80} />
+            <Avatar name={displayName || "?"} url={avatarHttpUrl} mxcUrl={avatarMxc} size={80} />
             {uploadingAvatar && (
               <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
                 <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/30 border-t-white" />

--- a/src/components/settings/ProfileSection.tsx
+++ b/src/components/settings/ProfileSection.tsx
@@ -78,7 +78,7 @@ export function ProfileSection() {
           <div className="-mt-10 flex items-end gap-4">
             <div className="relative flex-shrink-0">
               <div className="rounded-full border-[5px] border-bg-secondary">
-                <Avatar name={displayName || "?"} url={avatarHttpUrl} size={80} />
+                <Avatar name={displayName || "?"} url={avatarHttpUrl} mxcUrl={avatarMxc} size={80} />
               </div>
               {uploadingAvatar && (
                 <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">

--- a/src/components/sidebar/ChannelItem.tsx
+++ b/src/components/sidebar/ChannelItem.tsx
@@ -37,6 +37,7 @@ function VoiceParticipantEntry({ participant }: { participant: CallParticipant }
       <Avatar
         name={participant.displayName}
         url={participant.avatarUrl}
+        mxcUrl={participant.mxcAvatarUrl}
         size={20}
       />
       <span className="flex-1 truncate text-xs">

--- a/src/components/sidebar/ChannelSidebar.tsx
+++ b/src/components/sidebar/ChannelSidebar.tsx
@@ -284,6 +284,7 @@ export function ChannelSidebar() {
   const avatarUrl = user && client
     ? mxcToHttp(user.avatarUrl ?? null, client.getHomeserverUrl())
     : null;
+  const mxcAvatarUrl = user?.avatarUrl ?? null;
 
   return (
     <div className="flex w-60 flex-col bg-bg-secondary">
@@ -594,6 +595,7 @@ export function ChannelSidebar() {
           <Avatar
             name={displayName}
             url={avatarUrl}
+            mxcUrl={mxcAvatarUrl}
             size={32}
             presence={myPresence}
           />

--- a/src/components/sidebar/DmItem.tsx
+++ b/src/components/sidebar/DmItem.tsx
@@ -24,26 +24,27 @@ function useOtherDmUser(roomId: string) {
   const client = getMatrixClient();
 
   return useMemo(() => {
-    if (!client) return { userId: null, displayName: null, avatarUrl: null };
+    if (!client) return { userId: null, displayName: null, avatarUrl: null, mxcAvatarUrl: null };
     const room = client.getRoom(roomId);
-    if (!room) return { userId: null, displayName: null, avatarUrl: null };
+    if (!room) return { userId: null, displayName: null, avatarUrl: null, mxcAvatarUrl: null };
 
     const members = room.getJoinedMembers();
     const other = members.find((m) => m.userId !== myUserId) ?? members[0];
-    if (!other) return { userId: null, displayName: null, avatarUrl: null };
+    if (!other) return { userId: null, displayName: null, avatarUrl: null, mxcAvatarUrl: null };
 
     const hs = client.getHomeserverUrl();
     return {
       userId: other.userId,
       displayName: other.name || other.userId,
       avatarUrl: mxcToHttp(other.getMxcAvatarUrl(), hs),
+      mxcAvatarUrl: other.getMxcAvatarUrl() ?? null,
     };
   }, [roomId, myUserId, client]);
 }
 
 export function DmItem({ roomId, name, unreadCount, isSelected, onClick }: DmItemProps) {
   const openContextMenu = useUiStore((s) => s.openContextMenu);
-  const { userId: otherUserId, displayName, avatarUrl } = useOtherDmUser(roomId);
+  const { userId: otherUserId, displayName, avatarUrl, mxcAvatarUrl } = useOtherDmUser(roomId);
 
   const presence: PresenceStatus = usePresenceStore(
     (s) => s.presenceByUser.get(otherUserId ?? "")?.presence ?? "offline"
@@ -93,6 +94,7 @@ export function DmItem({ roomId, name, unreadCount, isSelected, onClick }: DmIte
       <Avatar
         name={shownName}
         url={avatarUrl}
+        mxcUrl={mxcAvatarUrl}
         size={32}
         presence={presence}
       />

--- a/src/components/sidebar/InviteItem.tsx
+++ b/src/components/sidebar/InviteItem.tsx
@@ -36,7 +36,7 @@ export function InviteItem({ room }: InviteItemProps) {
 
   return (
     <div className="flex items-center gap-2 rounded px-2 py-1">
-      <Avatar name={room.name} url={room.avatarUrl} size={32} />
+      <Avatar name={room.name} url={room.avatarUrl} mxcUrl={room.mxcAvatarUrl} size={32} />
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm text-text-primary">{room.name}</p>
         {room.inviteSender && (

--- a/src/components/sidebar/ServerIcon.tsx
+++ b/src/components/sidebar/ServerIcon.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from "react";
+import { useMatrixImage } from "@/utils/useMatrixImage";
 
 interface ServerIconProps {
   name: string;
-  avatarUrl: string | null;
+  avatarUrl?: string | null;
+  mxcAvatarUrl?: string | null;
   isSelected: boolean;
   unreadCount: number;
   onClick: () => void;
@@ -24,16 +26,19 @@ function getColor(name: string): string {
 export function ServerIcon({
   name,
   avatarUrl,
+  mxcAvatarUrl,
   isSelected,
   unreadCount,
   onClick,
 }: ServerIconProps) {
   const [imgError, setImgError] = useState(false);
+  const { src: blobSrc, loading } = useMatrixImage(mxcAvatarUrl, 96, 96);
 
-  // Reset error state when URL changes
+  const effectiveUrl = blobSrc ?? avatarUrl ?? null;
+
   useEffect(() => {
     setImgError(false);
-  }, [avatarUrl]);
+  }, [effectiveUrl]);
 
   const initials = name
     .split(" ")
@@ -42,7 +47,7 @@ export function ServerIcon({
     .slice(0, 2)
     .toUpperCase();
 
-  const showImage = avatarUrl && !imgError;
+  const showImage = effectiveUrl && !imgError;
 
   return (
     <div className="group relative">
@@ -69,11 +74,13 @@ export function ServerIcon({
       >
         {showImage ? (
           <img
-            src={avatarUrl}
+            src={effectiveUrl}
             alt={name}
             className="h-full w-full object-cover"
             onError={() => setImgError(true)}
           />
+        ) : loading ? (
+          <span className="flex h-full w-full animate-pulse items-center justify-center bg-bg-secondary" />
         ) : (
           <span
             className="flex h-full w-full items-center justify-center text-sm font-medium text-white"

--- a/src/components/sidebar/ServerSidebar.tsx
+++ b/src/components/sidebar/ServerSidebar.tsx
@@ -82,6 +82,7 @@ export function ServerSidebar() {
           <ServerIcon
             name={space.name}
             avatarUrl={space.avatarUrl}
+            mxcAvatarUrl={space.mxcAvatarUrl}
             isSelected={selectedSpaceId === space.roomId}
             unreadCount={unreadCounts.get(space.roomId) ?? 0}
             onClick={() => selectSpace(space.roomId)}

--- a/src/components/voice/VoiceChannelView.tsx
+++ b/src/components/voice/VoiceChannelView.tsx
@@ -188,6 +188,7 @@ export function VoiceChannelView({ roomId }: VoiceChannelViewProps) {
                     <Avatar
                       name={p.displayName}
                       url={p.avatarUrl}
+                      mxcUrl={p.mxcAvatarUrl}
                       size={48}
                     />
                     <span className="max-w-[80px] truncate text-xs text-text-secondary">

--- a/src/components/voice/VoiceParticipant.tsx
+++ b/src/components/voice/VoiceParticipant.tsx
@@ -70,6 +70,7 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
           <Avatar
             name={participant.displayName}
             url={participant.avatarUrl}
+            mxcUrl={participant.mxcAvatarUrl}
             size={80}
           />
         </div>

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -213,6 +213,7 @@ function participantToCallParticipant(
     userId: identity,
     displayName: member?.name ?? p.name ?? identity,
     avatarUrl: member ? mxcToHttp(member.getMxcAvatarUrl(), homeserverUrl) : null,
+    mxcAvatarUrl: member?.getMxcAvatarUrl() ?? null,
     isSpeaking: p.isSpeaking,
     isAudioMuted: !p.isMicrophoneEnabled,
     isVideoMuted: !p.isCameraEnabled,

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -31,6 +31,7 @@ export interface CallParticipant {
   userId: string;
   displayName: string;
   avatarUrl: string | null;
+  mxcAvatarUrl: string | null;
   isSpeaking: boolean;
   isAudioMuted: boolean;
   isVideoMuted: boolean;
@@ -162,6 +163,7 @@ function attachGroupCallListeners(
         userId: feed.userId,
         displayName: member?.name ?? feed.userId,
         avatarUrl: member ? mxcToHttp(member.getMxcAvatarUrl(), homeserverUrl) : null,
+        mxcAvatarUrl: member?.getMxcAvatarUrl() ?? null,
         isSpeaking: feed.isSpeaking(),
         isAudioMuted: feed.isAudioMuted(),
         isVideoMuted: feed.isVideoMuted(),

--- a/src/stores/memberStore.ts
+++ b/src/stores/memberStore.ts
@@ -4,6 +4,7 @@ export interface Member {
   userId: string;
   displayName: string;
   avatarUrl: string | null;
+  mxcAvatarUrl: string | null;
   membership: string;
   powerLevel: number;
 }

--- a/src/stores/messageStore.test.ts
+++ b/src/stores/messageStore.test.ts
@@ -8,6 +8,7 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
     senderId: "@user:matrix.org",
     senderName: "User",
     senderAvatar: null,
+    senderMxcAvatar: null,
     body: "Hello",
     formattedBody: null,
     timestamp: Date.now(),

--- a/src/stores/messageStore.ts
+++ b/src/stores/messageStore.ts
@@ -12,6 +12,7 @@ export interface Message {
   senderId: string;
   senderName: string;
   senderAvatar: string | null;
+  senderMxcAvatar: string | null;
   body: string;
   formattedBody: string | null;
   timestamp: number;

--- a/src/stores/roomStore.test.ts
+++ b/src/stores/roomStore.test.ts
@@ -6,6 +6,7 @@ function makeRoom(overrides: Partial<RoomSummary> = {}): RoomSummary {
     roomId: "!room1:matrix.org",
     name: "General",
     avatarUrl: null,
+    mxcAvatarUrl: null,
     topic: null,
     unreadCount: 0,
     isSpace: false,

--- a/src/stores/roomStore.ts
+++ b/src/stores/roomStore.ts
@@ -7,6 +7,7 @@ export interface RoomSummary {
   roomId: string;
   name: string;
   avatarUrl: string | null;
+  mxcAvatarUrl: string | null;
   topic: string | null;
   unreadCount: number;
   isSpace: boolean;

--- a/src/utils/useMatrixImage.ts
+++ b/src/utils/useMatrixImage.ts
@@ -1,0 +1,146 @@
+import { useState, useEffect } from "react";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { getMatrixClient } from "@/lib/matrix";
+
+/**
+ * Module-level cache: mxcUrl -> blob URL.
+ * Persists across component mounts so the same image is only fetched once.
+ */
+const blobCache = new Map<string, string>();
+
+/** Track in-flight fetches so multiple components requesting the same MXC URL
+ *  don't fire duplicate network requests. */
+const inflightRequests = new Map<string, Promise<string | null>>();
+
+function buildThumbnailUrl(
+  mxcUrl: string,
+  homeserverUrl: string,
+  width: number,
+  height: number,
+): string {
+  const parts = mxcUrl.slice(6).split("/");
+  const [serverName, mediaId] = parts;
+  const hs = homeserverUrl.replace(/\/$/, "");
+  return `${hs}/_matrix/client/v1/media/thumbnail/${serverName}/${mediaId}?width=${width}&height=${height}&method=crop`;
+}
+
+async function fetchImageAsBlob(
+  mxcUrl: string,
+  width: number,
+  height: number,
+): Promise<string | null> {
+  const cached = blobCache.get(mxcUrl);
+  if (cached) return cached;
+
+  const inflight = inflightRequests.get(mxcUrl);
+  if (inflight) return inflight;
+
+  const promise = (async (): Promise<string | null> => {
+    try {
+      const client = getMatrixClient();
+      if (!client) return null;
+
+      const hs = client.getHomeserverUrl();
+      const token = client.getAccessToken();
+      const url = buildThumbnailUrl(mxcUrl, hs, width, height);
+
+      const headers: Record<string, string> = {};
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+
+      const res = await tauriFetch(url, { method: "GET", headers });
+
+      if (!res.ok) {
+        // Fall back to legacy unauthenticated endpoint
+        const parts = mxcUrl.slice(6).split("/");
+        const [serverName, mediaId] = parts;
+        const legacyUrl = `${hs.replace(/\/$/, "")}/_matrix/media/v3/thumbnail/${serverName}/${mediaId}?width=${width}&height=${height}&method=crop`;
+        const legacyRes = await tauriFetch(legacyUrl, { method: "GET" });
+        if (!legacyRes.ok) return null;
+        const blob = await legacyRes.blob();
+        const blobUrl = URL.createObjectURL(blob);
+        blobCache.set(mxcUrl, blobUrl);
+        return blobUrl;
+      }
+
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      blobCache.set(mxcUrl, blobUrl);
+      return blobUrl;
+    } catch (err) {
+      console.warn("[useMatrixImage] Failed to fetch", mxcUrl, err);
+      return null;
+    } finally {
+      inflightRequests.delete(mxcUrl);
+    }
+  })();
+
+  inflightRequests.set(mxcUrl, promise);
+  return promise;
+}
+
+/**
+ * React hook that fetches a Matrix media image via the Tauri HTTP plugin
+ * (with proper Authorization header) and returns a blob URL for use in <img>.
+ *
+ * Caches results so each MXC URL is only fetched once across the app lifetime.
+ */
+export function useMatrixImage(
+  mxcUrl: string | null | undefined,
+  width = 96,
+  height = 96,
+): { src: string | null; loading: boolean } {
+  const [src, setSrc] = useState<string | null>(() =>
+    mxcUrl ? blobCache.get(mxcUrl) ?? null : null,
+  );
+  const [loading, setLoading] = useState(() =>
+    !!mxcUrl && !blobCache.has(mxcUrl),
+  );
+
+  useEffect(() => {
+    if (!mxcUrl || !mxcUrl.startsWith("mxc://")) {
+      setSrc(null);
+      setLoading(false);
+      return;
+    }
+
+    const cached = blobCache.get(mxcUrl);
+    if (cached) {
+      setSrc(cached);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    fetchImageAsBlob(mxcUrl, width, height).then((blobUrl) => {
+      if (!cancelled) {
+        setSrc(blobUrl);
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mxcUrl, width, height]);
+
+  return { src, loading };
+}
+
+/** Evict a single entry from the blob cache (e.g. after avatar change). */
+export function evictImageCache(mxcUrl: string): void {
+  const existing = blobCache.get(mxcUrl);
+  if (existing) {
+    URL.revokeObjectURL(existing);
+    blobCache.delete(mxcUrl);
+  }
+}
+
+/** Clear the entire image cache (e.g. on logout). */
+export function clearImageCache(): void {
+  for (const url of blobCache.values()) {
+    URL.revokeObjectURL(url);
+  }
+  blobCache.clear();
+}


### PR DESCRIPTION
Authenticated media endpoints on modern Matrix homeservers require Authorization headers that <img> tags cannot set. This adds a useMatrixImage hook that fetches images via tauriFetch with proper auth headers, converts to blob URLs, and caches them.

- New useMatrixImage hook with blob URL caching and legacy fallback
- Avatar and ServerIcon components accept mxcUrl prop
- All stores and event handlers now carry raw MXC URLs
- RoomStateEvent handler for real-time avatar updates
- All 19+ consumer components updated to pass mxcUrl

## Summary

<!-- Briefly describe what this PR does and why. -->

## Changes

<!-- List the key changes made in this PR. -->

-

## Test Plan

<!-- How did you verify this works? What should reviewers test? -->

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual testing: <!-- describe what you tested -->

## Screenshots

<!-- If this changes the UI, include before/after screenshots. -->

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
