### PR TITLE
Fix/livekit rejoin audio corruption

### DIFF
--- a/src/components/voice/RemoteAudioRenderer.tsx
+++ b/src/components/voice/RemoteAudioRenderer.tsx
@@ -30,20 +30,12 @@ function HiddenAudioTrack({
     const el = audioRef.current;
     if (!el) return;
 
-    // Build a fresh one-track stream for this audio track to avoid mixed-track corruption.
-    const sourceStream = trackRef.track.mediaStream;
-    if (!sourceStream) {
-      el.srcObject = null;
+    try {
+      trackRef.track.attach(el);
+    } catch (err) {
+      console.warn("Failed to attach LiveKit audio track:", err);
       return;
     }
-    const stream = new MediaStream();
-    for (const t of sourceStream.getAudioTracks()) {
-      if (!stream.getAudioTracks().some((existing) => existing.id === t.id)) {
-        stream.addTrack(t);
-      }
-    }
-
-    el.srcObject = stream;
     el.volume = Math.max(0, Math.min(1, volume));
     void el.play().catch(() => {});
 
@@ -55,6 +47,11 @@ function HiddenAudioTrack({
 
     return () => {
       if (audioRef.current) {
+        try {
+          trackRef.track.detach(audioRef.current);
+        } catch {
+          // best effort
+        }
         audioRef.current.pause();
         audioRef.current.srcObject = null;
       }

--- a/src/components/voice/RemoteAudioRenderer.tsx
+++ b/src/components/voice/RemoteAudioRenderer.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useRef } from "react";
+import { Track, type RemoteAudioTrack, type RemoteTrackPublication } from "livekit-client";
+import { getActiveLkRoom } from "@/lib/livekit";
+import { useCallStore } from "@/stores/callStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+interface AudioTrackRef {
+  key: string;
+  participantIdentity: string;
+  publication: RemoteTrackPublication;
+  track: RemoteAudioTrack;
+}
+
+function HiddenAudioTrack({ trackRef, muted, sinkId }: { trackRef: AudioTrackRef; muted: boolean; sinkId: string | null }) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el) return;
+
+    // Build a fresh one-track stream for this audio track to avoid mixed-track corruption.
+    const sourceStream = trackRef.track.mediaStream;
+    if (!sourceStream) {
+      el.srcObject = null;
+      return;
+    }
+    const stream = new MediaStream();
+    for (const t of sourceStream.getAudioTracks()) {
+      if (!stream.getAudioTracks().some((existing) => existing.id === t.id)) {
+        stream.addTrack(t);
+      }
+    }
+
+    el.srcObject = stream;
+    void el.play().catch(() => {});
+
+    if (sinkId && "setSinkId" in el) {
+      (el as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
+        .setSinkId(sinkId)
+        .catch((err) => console.warn("Failed to set audio output device:", err));
+    }
+
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.srcObject = null;
+      }
+    };
+  }, [trackRef, sinkId]);
+
+  return <audio ref={audioRef} autoPlay playsInline muted={muted} />;
+}
+
+export function RemoteAudioRenderer() {
+  const isDeafened = useCallStore((s) => s.isDeafened);
+  const participants = useCallStore((s) => s.participants);
+  const connectionState = useCallStore((s) => s.connectionState);
+  const audioOutputDeviceId = useSettingsStore((s) => s.audioOutputDeviceId);
+
+  // Recompute whenever call participants/state changes.
+  const trackRefs = useMemo(() => {
+    if (connectionState !== "connected") return [] as AudioTrackRef[];
+    const room = getActiveLkRoom();
+    if (!room) return [] as AudioTrackRef[];
+
+    const refs: AudioTrackRef[] = [];
+    const validIdentities = new Set(
+      Array.from(participants.keys())
+        .filter((k) => k.startsWith("lk:"))
+        .map((k) => k.slice(3)),
+    );
+
+    for (const [, rp] of room.remoteParticipants) {
+      if (!validIdentities.has(rp.identity)) continue;
+
+      for (const pub of rp.trackPublications.values()) {
+        if (pub.kind !== Track.Kind.Audio) continue;
+        if (pub.source === Track.Source.ScreenShare) continue;
+        const track = pub.track;
+        if (!track || track.kind !== Track.Kind.Audio) continue;
+
+        refs.push({
+          key: `${rp.identity}:${pub.trackSid ?? "audio"}`,
+          participantIdentity: rp.identity,
+          publication: pub,
+          track: track as RemoteAudioTrack,
+        });
+      }
+    }
+
+    return refs;
+  }, [participants, connectionState]);
+
+  if (trackRefs.length === 0) return null;
+
+  return (
+    <div className="hidden" aria-hidden="true">
+      {trackRefs.map((ref) => (
+        <HiddenAudioTrack
+          key={ref.key}
+          trackRef={ref}
+          muted={isDeafened}
+          sinkId={audioOutputDeviceId}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/voice/RemoteAudioRenderer.tsx
+++ b/src/components/voice/RemoteAudioRenderer.tsx
@@ -7,11 +7,23 @@ import { useSettingsStore } from "@/stores/settingsStore";
 interface AudioTrackRef {
   key: string;
   participantIdentity: string;
+  feedId: string;
+  source: Track.Source;
   publication: RemoteTrackPublication;
   track: RemoteAudioTrack;
 }
 
-function HiddenAudioTrack({ trackRef, muted, sinkId }: { trackRef: AudioTrackRef; muted: boolean; sinkId: string | null }) {
+function HiddenAudioTrack({
+  trackRef,
+  muted,
+  volume,
+  sinkId,
+}: {
+  trackRef: AudioTrackRef;
+  muted: boolean;
+  volume: number;
+  sinkId: string | null;
+}) {
   const audioRef = useRef<HTMLAudioElement>(null);
 
   useEffect(() => {
@@ -32,6 +44,7 @@ function HiddenAudioTrack({ trackRef, muted, sinkId }: { trackRef: AudioTrackRef
     }
 
     el.srcObject = stream;
+    el.volume = Math.max(0, Math.min(1, volume));
     void el.play().catch(() => {});
 
     if (sinkId && "setSinkId" in el) {
@@ -46,7 +59,7 @@ function HiddenAudioTrack({ trackRef, muted, sinkId }: { trackRef: AudioTrackRef
         audioRef.current.srcObject = null;
       }
     };
-  }, [trackRef, sinkId]);
+  }, [trackRef, sinkId, volume]);
 
   return <audio ref={audioRef} autoPlay playsInline muted={muted} />;
 }
@@ -55,6 +68,7 @@ export function RemoteAudioRenderer() {
   const isDeafened = useCallStore((s) => s.isDeafened);
   const participants = useCallStore((s) => s.participants);
   const connectionState = useCallStore((s) => s.connectionState);
+  const screenshareAudioPrefs = useCallStore((s) => s.screenshareAudioPrefs);
   const audioOutputDeviceId = useSettingsStore((s) => s.audioOutputDeviceId);
 
   // Recompute whenever call participants/state changes.
@@ -75,13 +89,17 @@ export function RemoteAudioRenderer() {
 
       for (const pub of rp.trackPublications.values()) {
         if (pub.kind !== Track.Kind.Audio) continue;
-        if (pub.source === Track.Source.ScreenShare) continue;
         const track = pub.track;
         if (!track || track.kind !== Track.Kind.Audio) continue;
+        if (pub.source !== Track.Source.Microphone && pub.source !== Track.Source.ScreenShareAudio) continue;
+
+        const feedId = pub.source === Track.Source.ScreenShareAudio ? `screenshare:lk:${rp.identity}` : `lk:${rp.identity}`;
 
         refs.push({
-          key: `${rp.identity}:${pub.trackSid ?? "audio"}`,
+          key: `${rp.identity}:${String(pub.source)}:${pub.trackSid ?? "audio"}`,
           participantIdentity: rp.identity,
+          feedId,
+          source: pub.source,
           publication: pub,
           track: track as RemoteAudioTrack,
         });
@@ -96,12 +114,21 @@ export function RemoteAudioRenderer() {
   return (
     <div className="hidden" aria-hidden="true">
       {trackRefs.map((ref) => (
+        (() => {
+          const isScreenshareAudio = ref.source === Track.Source.ScreenShareAudio;
+          const prefs = isScreenshareAudio ? screenshareAudioPrefs[ref.feedId] : undefined;
+          const muted = isDeafened || (isScreenshareAudio ? (prefs?.muted ?? false) : false);
+          const volume = isScreenshareAudio ? ((prefs?.volume ?? 100) / 100) : 1;
+          return (
         <HiddenAudioTrack
           key={ref.key}
           trackRef={ref}
-          muted={isDeafened}
+          muted={muted}
+          volume={volume}
           sinkId={audioOutputDeviceId}
         />
+          );
+        })()
       ))}
     </div>
   );

--- a/src/components/voice/ScreenshareFeedView.tsx
+++ b/src/components/voice/ScreenshareFeedView.tsx
@@ -10,7 +10,8 @@ interface ScreenshareFeedViewProps {
 export function ScreenshareFeedView({ feedId, displayName }: ScreenshareFeedViewProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const stream = getFeedStream(feedId);
-  const prefs = useCallStore((s) => s.screenshareAudioPrefs[feedId] ?? { muted: false, volume: 100 });
+  const rawPrefs = useCallStore((s) => s.screenshareAudioPrefs[feedId]);
+  const prefs = rawPrefs ?? { muted: false, volume: 100 };
   const setMuted = useCallStore((s) => s.setScreenshareAudioMuted);
   const setVolume = useCallStore((s) => s.setScreenshareAudioVolume);
 

--- a/src/components/voice/ScreenshareFeedView.tsx
+++ b/src/components/voice/ScreenshareFeedView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { getFeedStream } from "@/stores/callStore";
+import { useCallStore } from "@/stores/callStore";
 
 interface ScreenshareFeedViewProps {
   feedId: string;
@@ -9,6 +10,9 @@ interface ScreenshareFeedViewProps {
 export function ScreenshareFeedView({ feedId, displayName }: ScreenshareFeedViewProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const stream = getFeedStream(feedId);
+  const prefs = useCallStore((s) => s.screenshareAudioPrefs[feedId] ?? { muted: false, volume: 100 });
+  const setMuted = useCallStore((s) => s.setScreenshareAudioMuted);
+  const setVolume = useCallStore((s) => s.setScreenshareAudioVolume);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -34,8 +38,31 @@ export function ScreenshareFeedView({ feedId, displayName }: ScreenshareFeedView
         muted
         className="aspect-video w-full object-contain"
       />
-      <div className="border-t border-bg-tertiary px-3 py-2 text-sm text-text-secondary">
-        {displayName} is sharing
+      <div className="border-t border-bg-tertiary px-3 py-2">
+        <div className="mb-2 text-sm text-text-secondary">
+          {displayName} is sharing
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setMuted(feedId, !prefs.muted)}
+            className={`rounded px-2 py-1 text-xs ${prefs.muted ? "bg-bg-active text-text-primary" : "bg-green/20 text-green"}`}
+            title={prefs.muted ? "Unmute shared audio" : "Mute shared audio"}
+          >
+            {prefs.muted ? "Unmute Audio" : "Mute Audio"}
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={prefs.volume}
+            onChange={(e) => setVolume(feedId, Number(e.target.value))}
+            className="w-32 accent-accent"
+            aria-label="Shared audio volume"
+          />
+          <span className="w-10 text-right text-xs text-text-muted">{prefs.volume}%</span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/voice/VoiceChannelView.tsx
+++ b/src/components/voice/VoiceChannelView.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "@/components/common/Avatar";
 import { VoiceParticipant } from "./VoiceParticipant";
 import { VoiceChatPanel } from "./VoiceChatPanel";
 import { ScreenshareFeedView } from "./ScreenshareFeedView";
+import { RemoteAudioRenderer } from "./RemoteAudioRenderer";
 import { getMatrixClient } from "@/lib/matrix";
 import { loadRoomMessages } from "@/lib/matrixEventHandlers";
 
@@ -214,6 +215,7 @@ export function VoiceChannelView({ roomId }: VoiceChannelViewProps) {
         ) : (
           /* In call - show screenshares + participants grid */
           <div className="flex w-full max-w-3xl flex-1 flex-col gap-4">
+            <RemoteAudioRenderer />
             {screenshareFeeds.length > 0 && (
               <div className="grid w-full gap-4 sm:grid-cols-2">
                 {screenshareFeeds.map((f) => (

--- a/src/components/voice/VoiceParticipant.tsx
+++ b/src/components/voice/VoiceParticipant.tsx
@@ -83,7 +83,7 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
           ref={videoRef}
           autoPlay
           playsInline
-          muted={isLocal || isDeafened}
+          muted
           className="h-full w-full rounded-md object-cover"
         />
       ) : (

--- a/src/components/voice/VoiceParticipant.tsx
+++ b/src/components/voice/VoiceParticipant.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react";
 import { Avatar } from "@/components/common/Avatar";
 import { CallParticipant, getFeedStream } from "@/stores/callStore";
 import { useCallStore } from "@/stores/callStore";
-import { useSettingsStore } from "@/stores/settingsStore";
 
 interface VoiceParticipantProps {
   participant: CallParticipant;
@@ -11,9 +10,7 @@ interface VoiceParticipantProps {
 
 export function VoiceParticipant({ participant, isLocal = false }: VoiceParticipantProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const audioRef = useRef<HTMLAudioElement>(null);
   const isDeafened = useCallStore((s) => s.isDeafened);
-  const audioOutputDeviceId = useSettingsStore((s) => s.audioOutputDeviceId);
 
   const stream = participant.feedId ? getFeedStream(participant.feedId) : null;
   const hasVideo = stream?.getVideoTracks().some((t) => t.enabled) && !participant.isVideoMuted;
@@ -34,30 +31,6 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
     };
   }, [stream, hasVideo]);
 
-  // Attach audio stream for remote participants and apply output device
-  useEffect(() => {
-    const el = audioRef.current;
-    if (!el || isLocal) return;
-
-    if (stream) {
-      el.srcObject = stream;
-      if (audioOutputDeviceId && "setSinkId" in el) {
-        (el as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
-          .setSinkId(audioOutputDeviceId)
-          .catch((err) => console.warn("Failed to set audio output device:", err));
-      }
-    } else {
-      el.srcObject = null;
-    }
-
-    return () => {
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.srcObject = null;
-      }
-    };
-  }, [stream, isLocal, audioOutputDeviceId]);
-
   const isMuted = participant.isAudioMuted;
   const isSpeaking = participant.isSpeaking && !isMuted;
 
@@ -67,23 +40,13 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
         isSpeaking ? "ring-2 ring-green" : "ring-1 ring-bg-tertiary"
       }`}
     >
-      {/* Audio playback for remote participants */}
-      {!isLocal && (
-        <audio
-          ref={audioRef}
-          autoPlay
-          playsInline
-          muted={isDeafened}
-        />
-      )}
-
       {/* Video feed */}
       {hasVideo ? (
         <video
           ref={videoRef}
           autoPlay
           playsInline
-          muted
+          muted={isLocal || isDeafened}
           className="h-full w-full rounded-md object-cover"
         />
       ) : (

--- a/src/components/voice/VoiceParticipant.tsx
+++ b/src/components/voice/VoiceParticipant.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
 import { Avatar } from "@/components/common/Avatar";
 import { CallParticipant, getFeedStream } from "@/stores/callStore";
-import { useCallStore } from "@/stores/callStore";
 
 interface VoiceParticipantProps {
   participant: CallParticipant;
@@ -10,7 +9,6 @@ interface VoiceParticipantProps {
 
 export function VoiceParticipant({ participant, isLocal = false }: VoiceParticipantProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const isDeafened = useCallStore((s) => s.isDeafened);
 
   const stream = participant.feedId ? getFeedStream(participant.feedId) : null;
   const hasVideo = stream?.getVideoTracks().some((t) => t.enabled) && !participant.isVideoMuted;
@@ -21,7 +19,13 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
     if (!el) return;
 
     if (stream && hasVideo) {
-      el.srcObject = stream;
+      const videoOnly = new MediaStream();
+      for (const t of stream.getVideoTracks()) {
+        if (!videoOnly.getVideoTracks().some((existing) => existing.id === t.id)) {
+          videoOnly.addTrack(t);
+        }
+      }
+      el.srcObject = videoOnly;
     } else {
       el.srcObject = null;
     }
@@ -46,7 +50,7 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
           ref={videoRef}
           autoPlay
           playsInline
-          muted={isLocal || isDeafened}
+          muted
           className="h-full w-full rounded-md object-cover"
         />
       ) : (

--- a/src/components/voice/VoiceParticipant.tsx
+++ b/src/components/voice/VoiceParticipant.tsx
@@ -20,21 +20,42 @@ export function VoiceParticipant({ participant, isLocal = false }: VoiceParticip
 
   // Attach video stream when video is active
   useEffect(() => {
-    if (videoRef.current && stream && hasVideo) {
-      videoRef.current.srcObject = stream;
+    const el = videoRef.current;
+    if (!el) return;
+
+    if (stream && hasVideo) {
+      el.srcObject = stream;
+    } else {
+      el.srcObject = null;
     }
+
+    return () => {
+      if (videoRef.current) videoRef.current.srcObject = null;
+    };
   }, [stream, hasVideo]);
 
   // Attach audio stream for remote participants and apply output device
   useEffect(() => {
-    if (isLocal || !audioRef.current || !stream) return;
     const el = audioRef.current;
-    el.srcObject = stream;
-    if (audioOutputDeviceId && "setSinkId" in el) {
-      (el as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
-        .setSinkId(audioOutputDeviceId)
-        .catch((err) => console.warn("Failed to set audio output device:", err));
+    if (!el || isLocal) return;
+
+    if (stream) {
+      el.srcObject = stream;
+      if (audioOutputDeviceId && "setSinkId" in el) {
+        (el as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
+          .setSinkId(audioOutputDeviceId)
+          .catch((err) => console.warn("Failed to set audio output device:", err));
+      }
+    } else {
+      el.srcObject = null;
     }
+
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.srcObject = null;
+      }
+    };
   }, [stream, isLocal, audioOutputDeviceId]);
 
   const isMuted = participant.isAudioMuted;

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -405,6 +405,23 @@ function rebuildScreenshareFeeds(
   return feeds;
 }
 
+function removeParticipantMedia(identity: string) {
+  lkStreamMap.delete(`lk:${identity}`);
+  lkStreamMap.delete(`screenshare:lk:${identity}`);
+}
+
+function removeStaleFeedsForUser(currentIdentity: string) {
+  const currentUserId = extractUserId(currentIdentity);
+  for (const key of Array.from(lkStreamMap.keys())) {
+    if (!key.startsWith("lk:") && !key.startsWith("screenshare:lk:")) continue;
+    const identity = key.replace(/^screenshare:/, "").slice(3); // strip optional screenshare: + "lk:"
+    if (identity === currentIdentity) continue;
+    if (extractUserId(identity) === currentUserId) {
+      lkStreamMap.delete(key);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Connection lifecycle
 // ---------------------------------------------------------------------------
@@ -475,11 +492,19 @@ export async function joinLivekitCall(
   );
 
   lkRoom.on(RoomEvent.ParticipantConnected, () => {
+    // If the same Matrix user reconnects with a new LiveKit identity, purge any
+    // stale feed streams so they rejoin with a clean media state.
+    for (const [, rp] of lkRoom.remoteParticipants) {
+      removeStaleFeedsForUser(rp.identity);
+    }
+    syncStreamsFromRoom(lkRoom);
     const participants = rebuildLkParticipants(lkRoom, matrixClient, roomId);
-    useCallStore.setState({ participants });
+    const screenshareFeeds = rebuildScreenshareFeeds(lkRoom, matrixClient, roomId);
+    useCallStore.setState({ participants, screenshareFeeds });
   });
 
-  lkRoom.on(RoomEvent.ParticipantDisconnected, () => {
+  lkRoom.on(RoomEvent.ParticipantDisconnected, (participant: RemoteParticipant) => {
+    removeParticipantMedia(participant.identity);
     syncStreamsFromRoom(lkRoom);
     const participants = rebuildLkParticipants(lkRoom, matrixClient, roomId);
     const screenshareFeeds = rebuildScreenshareFeeds(lkRoom, matrixClient, roomId);
@@ -491,7 +516,8 @@ export async function joinLivekitCall(
     const current = useCallStore.getState().participants;
     const updated = new Map(current);
     for (const [key, p] of updated) {
-      updated.set(key, { ...p, isSpeaking: speakerIds.has(p.userId) });
+      const identity = p.feedId?.startsWith("lk:") ? p.feedId.slice(3) : p.userId;
+      updated.set(key, { ...p, isSpeaking: speakerIds.has(identity) });
     }
     useCallStore.setState({
       participants: updated,

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -2,6 +2,7 @@ import {
   Room,
   RoomEvent,
   Track,
+  AudioPresets,
   RemoteParticipant,
   RemoteTrackPublication,
   RemoteTrack,
@@ -486,6 +487,11 @@ export async function joinLivekitCall(
   const lkRoom = new Room({
     adaptiveStream: true,
     dynacast: true,
+    publishDefaults: {
+      audioPreset: AudioPresets.speech,
+      red: false,
+      dtx: false,
+    },
   });
 
   const store = useCallStore.getState();

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -23,6 +23,7 @@ let activeRoomId: string | null = null;
 
 /** MediaStream map shared with callStore's getFeedStream */
 const lkStreamMap = new Map<string, MediaStream>();
+const LK_DEBUG_MEDIA = true;
 
 export function getActiveLkRoom(): Room | null {
   return activeLkRoom;
@@ -34,6 +35,11 @@ export function getLkFeedStream(feedId: string): MediaStream | null {
 
 export function isLivekitActive(): boolean {
   return activeLkRoom !== null;
+}
+
+function logLkMedia(...args: unknown[]) {
+  if (!LK_DEBUG_MEDIA) return;
+  console.log("[livekit-media]", ...args);
 }
 
 // ---------------------------------------------------------------------------
@@ -355,9 +361,15 @@ function syncStreamsFromRoom(lkRoom: Room) {
     for (const t of mediaStream.getTracks()) {
       if (t.readyState === "ended") continue;
       // Main participant feed should expose at most one audio + one video track.
-      if (stream.getTracks().some((existing) => existing.kind === t.kind)) continue;
+      // If a participant rejoins/renegotiates, prefer the latest track for that kind.
+      const existingSameKind = stream.getTracks().find((existing) => existing.kind === t.kind);
+      if (existingSameKind && existingSameKind.id !== t.id) {
+        stream.removeTrack(existingSameKind);
+        logLkMedia("replaced track", { feedId, kind: t.kind, oldTrackId: existingSameKind.id, newTrackId: t.id });
+      }
       if (!stream.getTracks().some((existing) => existing.id === t.id)) {
         stream.addTrack(t);
+        logLkMedia("added track", { feedId, kind: t.kind, trackId: t.id });
       }
     }
   };
@@ -371,6 +383,15 @@ function syncStreamsFromRoom(lkRoom: Room) {
     const feedId = `lk:${rp.identity}`;
     for (const pub of rp.trackPublications.values()) {
       addPublicationTracks(feedId, pub);
+    }
+  }
+
+  if (LK_DEBUG_MEDIA) {
+    for (const [feedId, stream] of lkStreamMap) {
+      logLkMedia("feed snapshot", {
+        feedId,
+        tracks: stream.getTracks().map((t) => ({ id: t.id, kind: t.kind, readyState: t.readyState })),
+      });
     }
   }
 }
@@ -472,7 +493,14 @@ export async function joinLivekitCall(
   // Attach event listeners before connecting
   lkRoom.on(
     RoomEvent.TrackSubscribed,
-    (_track: RemoteTrack, _pub: RemoteTrackPublication, _participant: RemoteParticipant) => {
+    (track: RemoteTrack, pub: RemoteTrackPublication, participant: RemoteParticipant) => {
+      logLkMedia("TrackSubscribed", {
+        participant: participant.identity,
+        source: pub.source,
+        pubTrackSid: pub.trackSid,
+        kind: track.kind,
+        mediaTracks: track.mediaStream?.getTracks().map((t) => ({ id: t.id, kind: t.kind, readyState: t.readyState })),
+      });
       syncStreamsFromRoom(lkRoom);
       const participants = rebuildLkParticipants(lkRoom, matrixClient, roomId);
       const screenshareFeeds = rebuildScreenshareFeeds(lkRoom, matrixClient, roomId);
@@ -482,8 +510,15 @@ export async function joinLivekitCall(
 
   lkRoom.on(
     RoomEvent.TrackUnsubscribed,
-    (_track: RemoteTrack, _pub: RemoteTrackPublication, _participant: RemoteParticipant) => {
-      _track.detach();
+    (track: RemoteTrack, pub: RemoteTrackPublication, participant: RemoteParticipant) => {
+      logLkMedia("TrackUnsubscribed", {
+        participant: participant.identity,
+        source: pub.source,
+        pubTrackSid: pub.trackSid,
+        kind: track.kind,
+        mediaTracks: track.mediaStream?.getTracks().map((t) => ({ id: t.id, kind: t.kind, readyState: t.readyState })),
+      });
+      track.detach();
       syncStreamsFromRoom(lkRoom);
       const participants = rebuildLkParticipants(lkRoom, matrixClient, roomId);
       const screenshareFeeds = rebuildScreenshareFeeds(lkRoom, matrixClient, roomId);
@@ -491,7 +526,8 @@ export async function joinLivekitCall(
     },
   );
 
-  lkRoom.on(RoomEvent.ParticipantConnected, () => {
+  lkRoom.on(RoomEvent.ParticipantConnected, (participant: RemoteParticipant) => {
+    logLkMedia("ParticipantConnected", { participant: participant.identity });
     // If the same Matrix user reconnects with a new LiveKit identity, purge any
     // stale feed streams so they rejoin with a clean media state.
     for (const [, rp] of lkRoom.remoteParticipants) {
@@ -504,6 +540,7 @@ export async function joinLivekitCall(
   });
 
   lkRoom.on(RoomEvent.ParticipantDisconnected, (participant: RemoteParticipant) => {
+    logLkMedia("ParticipantDisconnected", { participant: participant.identity });
     removeParticipantMedia(participant.identity);
     syncStreamsFromRoom(lkRoom);
     const participants = rebuildLkParticipants(lkRoom, matrixClient, roomId);

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -353,6 +353,9 @@ function syncStreamsFromRoom(lkRoom: Room) {
     }
 
     for (const t of mediaStream.getTracks()) {
+      if (t.readyState === "ended") continue;
+      // Main participant feed should expose at most one audio + one video track.
+      if (stream.getTracks().some((existing) => existing.kind === t.kind)) continue;
       if (!stream.getTracks().some((existing) => existing.id === t.id)) {
         stream.addTrack(t);
       }

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -344,7 +344,7 @@ function syncStreamsFromRoom(lkRoom: Room) {
     if (pub.source === Track.Source.ScreenShare) {
       // Build a fresh stream to avoid reusing/mutating SDK-owned streams across re-subscribes.
       const stream = new MediaStream();
-      for (const t of mediaStream.getTracks()) {
+      for (const t of mediaStream.getVideoTracks()) {
         if (!stream.getTracks().some((existing) => existing.id === t.id)) {
           stream.addTrack(t);
         }
@@ -359,10 +359,10 @@ function syncStreamsFromRoom(lkRoom: Room) {
       lkStreamMap.set(feedId, stream);
     }
 
-    for (const t of mediaStream.getTracks()) {
+    for (const t of mediaStream.getVideoTracks()) {
       if (t.readyState === "ended") continue;
       // Main participant feed should expose at most one audio + one video track.
-      // If a participant rejoins/renegotiates, prefer the latest track for that kind.
+      // Participant feeds are video-only; prefer the latest video track.
       const existingSameKind = stream.getTracks().find((existing) => existing.kind === t.kind);
       if (existingSameKind && existingSameKind.id !== t.id) {
         stream.removeTrack(existingSameKind);

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -330,43 +330,44 @@ function rebuildLkParticipants(
 function syncStreamsFromRoom(lkRoom: Room) {
   lkStreamMap.clear();
 
-  // Local tracks
-  const localId = `lk:${lkRoom.localParticipant.identity}`;
-  for (const pub of lkRoom.localParticipant.trackPublications.values()) {
-    if (pub.track?.mediaStream) {
-      if (pub.source === Track.Source.ScreenShare) {
-        lkStreamMap.set(`screenshare:${localId}`, pub.track.mediaStream);
-      } else {
-        const existing = lkStreamMap.get(localId);
-        if (existing) {
-          for (const t of pub.track.mediaStream.getTracks()) {
-            if (!existing.getTracks().includes(t)) existing.addTrack(t);
-          }
-        } else {
-          lkStreamMap.set(localId, pub.track.mediaStream);
+  const addPublicationTracks = (feedId: string, pub: { source: Track.Source; track?: { mediaStream?: MediaStream } | null }) => {
+    const mediaStream = pub.track?.mediaStream;
+    if (!mediaStream) return;
+
+    if (pub.source === Track.Source.ScreenShare) {
+      // Build a fresh stream to avoid reusing/mutating SDK-owned streams across re-subscribes.
+      const stream = new MediaStream();
+      for (const t of mediaStream.getTracks()) {
+        if (!stream.getTracks().some((existing) => existing.id === t.id)) {
+          stream.addTrack(t);
         }
       }
+      lkStreamMap.set(`screenshare:${feedId}`, stream);
+      return;
     }
+
+    let stream = lkStreamMap.get(feedId);
+    if (!stream) {
+      stream = new MediaStream();
+      lkStreamMap.set(feedId, stream);
+    }
+
+    for (const t of mediaStream.getTracks()) {
+      if (!stream.getTracks().some((existing) => existing.id === t.id)) {
+        stream.addTrack(t);
+      }
+    }
+  };
+
+  const localId = `lk:${lkRoom.localParticipant.identity}`;
+  for (const pub of lkRoom.localParticipant.trackPublications.values()) {
+    addPublicationTracks(localId, pub);
   }
 
-  // Remote tracks
   for (const [, rp] of lkRoom.remoteParticipants) {
     const feedId = `lk:${rp.identity}`;
     for (const pub of rp.trackPublications.values()) {
-      if (pub.track?.mediaStream) {
-        if (pub.source === Track.Source.ScreenShare) {
-          lkStreamMap.set(`screenshare:${feedId}`, pub.track.mediaStream);
-        } else {
-          const existing = lkStreamMap.get(feedId);
-          if (existing) {
-            for (const t of pub.track.mediaStream.getTracks()) {
-              if (!existing.getTracks().includes(t)) existing.addTrack(t);
-            }
-          } else {
-            lkStreamMap.set(feedId, pub.track.mediaStream);
-          }
-        }
-      }
+      addPublicationTracks(feedId, pub);
     }
   }
 }
@@ -428,6 +429,18 @@ export async function joinLivekitCall(
 ): Promise<void> {
   const webrtcErr = checkWebRTCSupport();
   if (webrtcErr) throw new Error(webrtcErr);
+
+  // Defensive cleanup in case a previous room is still tearing down.
+  if (activeLkRoom) {
+    try {
+      activeLkRoom.removeAllListeners();
+      activeLkRoom.disconnect();
+    } catch (err) {
+      console.warn("[livekit] Failed to disconnect previous room before join:", err);
+    }
+    activeLkRoom = null;
+    lkStreamMap.clear();
+  }
 
   const lkRoom = new Room({
     adaptiveStream: true,
@@ -541,9 +554,37 @@ export async function joinLivekitCall(
 export async function leaveLivekitCall(matrixClient: MatrixClient): Promise<void> {
   stopMembershipRenewal();
 
-  if (activeLkRoom) {
-    activeLkRoom.disconnect();
-    activeLkRoom = null;
+  const roomToClose = activeLkRoom;
+  activeLkRoom = null;
+
+  if (roomToClose) {
+    try {
+      // Prevent intentional disconnect from re-entering store.leaveCall() via RoomEvent.Disconnected.
+      roomToClose.removeAllListeners();
+
+      for (const pub of roomToClose.localParticipant.trackPublications.values()) {
+        try {
+          pub.track?.detach?.();
+          pub.track?.stop?.();
+        } catch {
+          // best effort
+        }
+      }
+
+      for (const [, rp] of roomToClose.remoteParticipants) {
+        for (const pub of rp.trackPublications.values()) {
+          try {
+            pub.track?.detach?.();
+          } catch {
+            // best effort
+          }
+        }
+      }
+
+      roomToClose.disconnect();
+    } catch (err) {
+      console.warn("[livekit] Error while disconnecting room:", err);
+    }
   }
 
   if (activeRoomId) {

--- a/src/lib/matrixEventHandlers.ts
+++ b/src/lib/matrixEventHandlers.ts
@@ -394,6 +394,7 @@ async function applySyncReady(client: MatrixClient, hasInitiallySyncedRef: { cur
 let _registeredClient: MatrixClient | null = null;
 let _verificationCleanup: (() => void) | null = null;
 let _voiceRescanInterval: ReturnType<typeof setInterval> | null = null;
+const _voiceStateOnlyMissingSince = new Map<string, number>();
 
 export function registerEventHandlers(client: MatrixClient): void {
   // Prevent registering duplicate listeners on the same client instance
@@ -711,6 +712,8 @@ function scanVoiceParticipants(client: MatrixClient, roomId: string): void {
 
   const homeserverUrl = client.getHomeserverUrl();
   const activeUserIds = new Set<string>();
+  const stateOnlyUserIds = new Set<string>();
+  const sdkGroupCallUserIds = new Set<string>();
   const myUserId = client.getUserId();
 
   // Strategy 1: Use SDK's GroupCall if one exists for this room
@@ -720,6 +723,7 @@ function scanVoiceParticipants(client: MatrixClient, roomId: string): void {
     if (gcParticipants && gcParticipants.size > 0) {
       for (const [member] of gcParticipants) {
         activeUserIds.add(member.userId);
+        sdkGroupCallUserIds.add(member.userId);
       }
       console.debug(`[voice] Room ${roomId}: SDK GroupCall found ${gcParticipants.size} participants`);
     }
@@ -784,6 +788,9 @@ function scanVoiceParticipants(client: MatrixClient, roomId: string): void {
 
     if (isActive) {
       activeUserIds.add(userId);
+      if (!sdkGroupCallUserIds.has(userId)) {
+        stateOnlyUserIds.add(userId);
+      }
       console.debug(`[voice] Room ${roomId}: state event detected active user ${userId} (key=${stateKey})`);
     }
   }
@@ -793,8 +800,33 @@ function scanVoiceParticipants(client: MatrixClient, roomId: string): void {
   }
 
   const participants: CallParticipant[] = [];
+  const callState = useCallStore.getState();
+  const isActiveLivekitRoom =
+    callState.activeCallRoomId === roomId && callState.connectionState === "connected";
+  const livekitUserIds = isActiveLivekitRoom
+    ? new Set(Array.from(callState.participants.values()).map((p) => p.userId))
+    : null;
+  if (isActiveLivekitRoom && myUserId) livekitUserIds?.add(myUserId);
+  const nowMs = Date.now();
+
   for (const userId of activeUserIds) {
     if (userId === myUserId && useCallStore.getState().activeCallRoomId === roomId) continue;
+
+    // Fallback stale detection: if a user is only present in Matrix call-member state
+    // but not in the actual connected LiveKit participant list for this active call,
+    // hide them after a short grace period.
+    if (isActiveLivekitRoom && stateOnlyUserIds.has(userId) && livekitUserIds && !livekitUserIds.has(userId)) {
+      const staleKey = `${roomId}|${userId}`;
+      const firstSeenMissing = _voiceStateOnlyMissingSince.get(staleKey) ?? nowMs;
+      _voiceStateOnlyMissingSince.set(staleKey, firstSeenMissing);
+      if (nowMs - firstSeenMissing > 60_000) {
+        console.debug(`[voice] Room ${roomId}: hiding stale state-only voice member ${userId} (missing from LiveKit >60s)`);
+        continue;
+      }
+    } else {
+      _voiceStateOnlyMissingSince.delete(`${roomId}|${userId}`);
+    }
+
     const member = room.getMember(userId);
     if (!member) continue;
     participants.push({
@@ -807,6 +839,13 @@ function scanVoiceParticipants(client: MatrixClient, roomId: string): void {
       isVideoMuted: true,
       feedId: null,
     });
+  }
+
+  // Cleanup stale tracking entries for users no longer present in this room scan.
+  for (const key of Array.from(_voiceStateOnlyMissingSince.keys())) {
+    if (!key.startsWith(`${roomId}|`)) continue;
+    const userId = key.slice(roomId.length + 1);
+    if (!activeUserIds.has(userId)) _voiceStateOnlyMissingSince.delete(key);
   }
 
   useCallStore.getState().setRoomParticipants(roomId, participants);

--- a/src/lib/matrixEventHandlers.ts
+++ b/src/lib/matrixEventHandlers.ts
@@ -393,6 +393,7 @@ async function applySyncReady(client: MatrixClient, hasInitiallySyncedRef: { cur
 
 let _registeredClient: MatrixClient | null = null;
 let _verificationCleanup: (() => void) | null = null;
+let _voiceRescanInterval: ReturnType<typeof setInterval> | null = null;
 
 export function registerEventHandlers(client: MatrixClient): void {
   // Prevent registering duplicate listeners on the same client instance
@@ -400,6 +401,10 @@ export function registerEventHandlers(client: MatrixClient): void {
   if (_registeredClient === client) return;
   _verificationCleanup?.();
   _verificationCleanup = null;
+  if (_voiceRescanInterval) {
+    clearInterval(_voiceRescanInterval);
+    _voiceRescanInterval = null;
+  }
   _registeredClient = client;
 
   _verificationCleanup = subscribeVerificationEvents(client);
@@ -663,7 +668,7 @@ export function registerEventHandlers(client: MatrixClient): void {
 
   // Periodic re-scan: state events can be missed (e.g. during initial sync race).
   // Re-scan voice rooms every 15 seconds to catch any missed updates.
-  setInterval(() => {
+  _voiceRescanInterval = setInterval(() => {
     const rooms = client.getRooms();
     for (const room of rooms) {
       const hasCallEvents =
@@ -767,7 +772,14 @@ function scanVoiceParticipants(client: MatrixClient, roomId: string): void {
 
     // Format 3: Per-device session content (has "application" field)
     if (!isActive && typeof content["application"] === "string") {
-      isActive = true;
+      const expiresMs = content["expires"] ?? content["expires_ts"];
+      const createdTs = content["created_ts"] ?? event.getTs();
+      if (typeof expiresMs === "number" && typeof createdTs === "number") {
+        isActive = createdTs + expiresMs >= now;
+      } else {
+        // If the event omits expiry metadata, keep legacy behavior.
+        isActive = true;
+      }
     }
 
     if (isActive) {

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -45,6 +45,7 @@ interface CallState {
   participants: Map<string, CallParticipant>;
   /** Active screenshare feeds for the current call (feedId -> displayName) */
   screenshareFeeds: { feedId: string; userId: string; displayName: string }[];
+  screenshareAudioPrefs: Record<string, { muted: boolean; volume: number }>;
   activeSpeakerId: string | null;
   participantsByRoom: Map<string, CallParticipant[]>;
 
@@ -54,6 +55,8 @@ interface CallState {
   toggleVideo: () => Promise<void>;
   toggleDeafen: () => void;
   toggleScreenShare: () => Promise<void>;
+  setScreenshareAudioMuted: (feedId: string, muted: boolean) => void;
+  setScreenshareAudioVolume: (feedId: string, volume: number) => void;
   setParticipants: (participants: Map<string, CallParticipant>) => void;
   setActiveSpeaker: (userId: string | null) => void;
   setConnectionState: (state: CallConnectionState) => void;
@@ -79,6 +82,7 @@ const initialState = {
   isScreenSharing: false,
   participants: new Map<string, CallParticipant>(),
   screenshareFeeds: [] as { feedId: string; userId: string; displayName: string }[],
+  screenshareAudioPrefs: {} as Record<string, { muted: boolean; volume: number }>,
   activeSpeakerId: null,
   participantsByRoom: new Map<string, CallParticipant[]>(),
 };
@@ -264,6 +268,31 @@ export const useCallStore = create<CallState>()((set, get) => ({
       const lkRoom = getActiveLkRoom();
       set({ isScreenSharing: lkRoom?.localParticipant.isScreenShareEnabled ?? false });
     }
+  },
+
+  setScreenshareAudioMuted: (feedId, muted) => {
+    set((state) => ({
+      screenshareAudioPrefs: {
+        ...state.screenshareAudioPrefs,
+        [feedId]: {
+          muted,
+          volume: state.screenshareAudioPrefs[feedId]?.volume ?? 100,
+        },
+      },
+    }));
+  },
+
+  setScreenshareAudioVolume: (feedId, volume) => {
+    const clamped = Math.max(0, Math.min(100, volume));
+    set((state) => ({
+      screenshareAudioPrefs: {
+        ...state.screenshareAudioPrefs,
+        [feedId]: {
+          muted: state.screenshareAudioPrefs[feedId]?.muted ?? false,
+          volume: clamped,
+        },
+      },
+    }));
   },
 
   setParticipants: (participants) => set({ participants }),

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -135,9 +135,15 @@ export const useCallStore = create<CallState>()((set, get) => ({
       return;
     }
 
-    // Leave current call if in one
-    if (get().activeCallRoomId) {
-      get().leaveCall();
+    // Leave current call if in one. Await teardown to avoid overlapping rooms/listeners.
+    if (get().activeCallRoomId && client) {
+      try {
+        await leaveLivekitCall(client);
+      } catch (err) {
+        console.warn("Error during pre-join LiveKit leave:", err);
+      }
+      const roomParticipants = get().participantsByRoom;
+      set({ ...initialState, participantsByRoom: roomParticipants });
     }
 
     set({ connectionState: "connecting", activeCallRoomId: roomId, error: null });


### PR DESCRIPTION
# PR: Fix Voice Rejoin Audio Corruption + Stale Voice Members + Screenshare Audio Controls

  ## Summary
  This PR fixes several voice call reliability issues in Concord, especially around users leaving/rejoining voice calls causing severe static/robotic audio.

  It also improves voice roster cleanup for stuck users and adds local controls for shared screen audio.

  ## Key Fixes

  ### 1. Fix rejoin audio corruption / static after participants leave and rejoin
  - Refactored remote audio playback to use a dedicated `RemoteAudioRenderer`
  - Switched remote audio attachment to LiveKit track lifecycle (`track.attach()` / `track.detach()`)
  - Removed fragile per-tile remote audio playback
  - Ensured video tiles only render muted video (no accidental duplicate audio)
  - Improved LiveKit room teardown/rejoin cleanup to avoid stale listeners/streams

  ### 2. Screenshare audio controls (local playback only)
  - Added local controls for screen share audio:
    - mute/unmute shared audio
    - volume slider
  - Controls only affect local playback (do not mute the other user)

  ### 3. Stale / stuck voice member cleanup
  - Improved periodic voice membership rescans (every 15s)
  - Properly respects call-member expiry (`created_ts + expires`)
  - Added fallback heuristic for malformed/stuck state:
    - if a user appears only in Matrix call-member state but is not actually connected in LiveKit for the active call, hide them after a grace period

  ## Why
  Previously, voice calls could become unusable after participant rejoin events due to audio corruption/static. In addition, users could get stuck in the voice roster
  due to stale MatrixRTC state events.

  This PR improves both the real-time media path and the voice roster state handling.

  ## Testing Notes
  Please test:
  - User leaves and rejoins voice call multiple times
  - Multiple participants rejoin in sequence
  - Screen share with system audio playback + local mute/volume controls
  - Stuck voice member entries disappearing automatically after expiry / grace period